### PR TITLE
Arguments Processing Fixes (and other small tweaks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+# macOS Finder Forks
+.DS_Store
+
+## User settings
+xcuserdata/
+
+## Gcc Patch
+/*.gcno

--- a/MenuBarTrigger.xcodeproj/project.pbxproj
+++ b/MenuBarTrigger.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		230B99B62327A9220049970A /* serialize.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = serialize.js; path = ../../../Scripts/serialize.js; sourceTree = "<group>"; };
+		230B99B62327A9220049970A /* serialize.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = serialize.js; sourceTree = "<group>"; };
 		23402D4D20CBE2C700D7BC47 /* CustomViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomViewController.swift; sourceTree = "<group>"; };
 		239E746B20574B700099C8CC /* MenuBarTrigger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MenuBarTrigger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		239E746E20574B700099C8CC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -93,7 +93,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0910;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = taniacomputer;
 				TargetAttributes = {
 					239E746A20574B700099C8CC = {
@@ -277,9 +277,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 58T9QBNJ2C;
+				DEVELOPMENT_TEAM = W86HTNC7AH;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = MenuBarTrigger/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -293,9 +294,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 58T9QBNJ2C;
+				DEVELOPMENT_TEAM = W86HTNC7AH;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = MenuBarTrigger/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/MenuBarTrigger.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MenuBarTrigger.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MenuBarTrigger/AppDelegate.swift
+++ b/MenuBarTrigger/AppDelegate.swift
@@ -31,6 +31,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
      
         var file:LocalWebFile = (nil, nil)
         let numberOfArguments = Int(CommandLine.argc)
+        if numberOfArguments == 1  {
+             // If numberOfArguments is only 1, then no arguments were set.
+             // (CommandLine() counts the actual app path itself as an argument. Surprise?).
+             // We need arguments to work, so nothing means the user needs help.
+             print("No arguments were specified. Did you need --help?")
+             quit()
+         }
         var index = 1
         while index < numberOfArguments {
             let arg = CommandLine.arguments[index]

--- a/MenuBarTrigger/AppDelegate.swift
+++ b/MenuBarTrigger/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
      
         var file:LocalWebFile = (nil, nil)
         let numberOfArguments = Int(CommandLine.argc)
-        var index = 0
+        var index = 1
         while index < numberOfArguments {
             let arg = CommandLine.arguments[index]
             var jamfVerbAndName = ""

--- a/MenuBarTrigger/AppDelegate.swift
+++ b/MenuBarTrigger/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
      
         var file:LocalWebFile = (nil, nil)
         let numberOfArguments = Int(CommandLine.argc)
-        var index = 1
+        var index = 0
         while index < numberOfArguments {
             let arg = CommandLine.arguments[index]
             var jamfVerbAndName = ""
@@ -97,13 +97,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 }
                 index += 1
-            case "--help", "-h":
+            case "--help":
                 displayManPage()
             case "-NSDocumentRevisionsDebugMode":
                 index += 1
                 break;
             default:
-                error(err: "Unknown argument: \(arg)")
+                error(err: "Unknown or missing argument(s): \(arg)")
             }
             index += 1
         }

--- a/MenuBarTrigger/Base.lproj/Main.storyboard
+++ b/MenuBarTrigger/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -620,7 +620,7 @@
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
-                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">

--- a/MenuBarTrigger/CustomViewController.swift
+++ b/MenuBarTrigger/CustomViewController.swift
@@ -62,8 +62,8 @@ class CustomViewController: NSViewController, WKNavigationDelegate, WKUIDelegate
 	
   func createTaskArray() {
 		var path = "/usr/local/bin/jamf"
-		let max = commandviews.count - 1
-		for i in 0...max {
+        let max = commandviews.count
+        for i in 0..<max {
             
 			if commandviews[i].jssCommand.first == "sleep" {
 				path = "/bin/sleep"


### PR DESCRIPTION
Fixes #1 by changing `createTaskArray()` to evaluate `commandViews.count` using a Half-Open Range Operator, which accomplishes the same goal as the old code without causing a SIGILL when no arguments are provided. Yay!

In the process of fixing #1, I also addressed some related issues with arguments processing:
- both the `--height` and `--help` arguments claimed the shortcut `-h`. In practice, `-h` always meant `--height`: the code now reflects this practically.
- the default error message implicitly assumed you provided single (bad) arguement, which could be confusing. Changed language to clearly indicate that you may have provided no arguements at all, or that multiple arguments were bad. Pedantic, but helpful?
- The function evaluation math assumed you had at least one argument. This resulted in a user _getting no feedback at all_ if they ran the program with no arguments, which is confusing. Running with no arguments will now show the default error message.

I also added a `.gitignore` because .DS_Store files are evil. Some of the Xcode project files also changed, because _reasons_, and those are included here for completeness.